### PR TITLE
Add Controller Advice

### DIFF
--- a/src/main/java/com/acolque/miniwalletapi/controllers/ControllerExceptionHandler.java
+++ b/src/main/java/com/acolque/miniwalletapi/controllers/ControllerExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.acolque.miniwalletapi.controllers;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.client.RestClientException;
+
+@ControllerAdvice
+public class ControllerExceptionHandler {
+
+    @ExceptionHandler(RestClientException.class)
+    public ResponseEntity<String> handleRestClientException(RestClientException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(String.format("Error en una api -> %s", ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Ocurrió una excepción no controlada: " + ex.getMessage());
+    }
+}

--- a/src/main/java/com/acolque/miniwalletapi/entities/CryptoYaDollarDto.java
+++ b/src/main/java/com/acolque/miniwalletapi/entities/CryptoYaDollarDto.java
@@ -1,10 +1,14 @@
 package com.acolque.miniwalletapi.entities;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CryptoYaDollarDto {
 
     private double oficial;

--- a/src/test/java/com/acolque/miniwalletapi/controllers/ControllerExceptionHandlerTest.java
+++ b/src/test/java/com/acolque/miniwalletapi/controllers/ControllerExceptionHandlerTest.java
@@ -1,0 +1,40 @@
+package com.acolque.miniwalletapi.controllers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.web.client.RestClientException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ControllerExceptionHandlerTest {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @MockBean
+    private PingController pingController;
+
+    @Test
+    public void testRestClientExceptionHandled() {
+        when(pingController.ping()).thenThrow(RestClientException.class);
+
+        ResponseEntity<String> response = testRestTemplate.getForEntity("/ping", String.class);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    public void testUnhandledException() {
+        when(pingController.ping()).thenThrow(RuntimeException.class);
+
+        ResponseEntity<String> response = testRestTemplate.getForEntity("/ping", String.class);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+}

--- a/src/test/java/com/acolque/miniwalletapi/controllers/WalletControllerTest.java
+++ b/src/test/java/com/acolque/miniwalletapi/controllers/WalletControllerTest.java
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.client.RestClientException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 public class WalletControllerTest {
@@ -26,5 +28,12 @@ public class WalletControllerTest {
         double result = controller.getDollarBluePrice();
 
         assertEquals(priceExpected, result);
+    }
+
+    @Test
+    public void testGetDollarBluePriceThrows() {
+        when(dollarService.getDollarBluePrice()).thenThrow(RestClientException.class);
+
+        assertThrows(RestClientException.class, () -> controller.getDollarBluePrice());
     }
 }


### PR DESCRIPTION
##Qué
Agrego un controller advice para capturar los posibles errores de la api y devolver un error más compresible para los que consuman la api

##Cómo
Haciendo uso de `@ControllerAdvice` de Java