### PR TITLE
Add dollar endpoint and add cache

### DIFF
--- a/src/main/java/com/acolque/miniwalletapi/MiniWalletApiApplication.java
+++ b/src/main/java/com/acolque/miniwalletapi/MiniWalletApiApplication.java
@@ -2,8 +2,10 @@ package com.acolque.miniwalletapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MiniWalletApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/acolque/miniwalletapi/configs/CacheConfig.java
+++ b/src/main/java/com/acolque/miniwalletapi/configs/CacheConfig.java
@@ -1,0 +1,19 @@
+package com.acolque.miniwalletapi.configs;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String CRYPTO_YA_API_CACHE_NAME = "cryptoYaApi";
+
+    @Bean
+    public CacheManager getCacheManager() {
+        return new ConcurrentMapCacheManager(CRYPTO_YA_API_CACHE_NAME);
+    }
+}

--- a/src/main/java/com/acolque/miniwalletapi/controllers/DollarController.java
+++ b/src/main/java/com/acolque/miniwalletapi/controllers/DollarController.java
@@ -6,21 +6,21 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/wallet")
-public class WalletController {
+@RequestMapping("/dolar")
+public class DollarController {
 
     private final DollarService dollarService;
 
-    public WalletController(DollarService dollarService) {
+    public DollarController(DollarService dollarService) {
         this.dollarService = dollarService;
     }
 
-    @GetMapping("/dolar/blue")
+    @GetMapping("/blue")
     public double getDollarBluePrice() {
         return dollarService.getDollarBluePrice();
     }
 
-    @GetMapping("/dolar/brecha")
+    @GetMapping("/brecha")
     public String getDiffBetweenDollarBlueAndOfficial() {
         return dollarService.getDiffBetweenDollarBlueAndOfficial();
     }

--- a/src/main/java/com/acolque/miniwalletapi/datasource/apis/CryptoYaApi.java
+++ b/src/main/java/com/acolque/miniwalletapi/datasource/apis/CryptoYaApi.java
@@ -1,12 +1,16 @@
 package com.acolque.miniwalletapi.datasource.apis;
 
 import com.acolque.miniwalletapi.entities.DollarInfoDto;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.Objects;
 import java.util.Optional;
+
+import static com.acolque.miniwalletapi.configs.CacheConfig.CRYPTO_YA_API_CACHE_NAME;
 
 @Component
 public class CryptoYaApi implements DollarDataSource {
@@ -18,6 +22,7 @@ public class CryptoYaApi implements DollarDataSource {
     }
 
     @Override
+    @Cacheable(CRYPTO_YA_API_CACHE_NAME)
     public Optional<DollarInfoDto> getDollarInfo() {
         try {
             DollarInfoDto resultDto = restTemplate.getForObject("https://criptoya.com/api/dolar", DollarInfoDto.class);
@@ -25,5 +30,11 @@ public class CryptoYaApi implements DollarDataSource {
         } catch (RestClientException ex) {
             throw new RestClientException(String.format("Error en la api de CryptoYa: %s", ex.getMessage()), ex);
         }
+    }
+
+    @CacheEvict(value = CRYPTO_YA_API_CACHE_NAME, allEntries = true)
+    @Scheduled(fixedRateString = "${caching.ttl.general}")
+    public void clean() {
+        System.out.println("limpiando crypto ya api cache");
     }
 }

--- a/src/main/java/com/acolque/miniwalletapi/services/DollarService.java
+++ b/src/main/java/com/acolque/miniwalletapi/services/DollarService.java
@@ -16,15 +16,15 @@ public class DollarService {
     }
 
     public double getDollarBluePrice() {
-        return dollarDataSource.getDollarInfo().map(DollarInfoDto::getBlue).orElse(0D);
+        return dollarDataSource.getDollarInfo()
+                .map(DollarInfoDto::getBlue)
+                .orElse(0D);
     }
 
     public String getDiffBetweenDollarBlueAndOfficial() {
-        Optional<DollarInfoDto> dollarInfo = dollarDataSource.getDollarInfo();
-        if (dollarInfo.isPresent()) {
-            Double diffPercentage = (dollarInfo.get().getBlue()-dollarInfo.get().getOficial())*100/dollarInfo.get().getBlue();
-            return String.format("%s%%", diffPercentage.intValue());
-        }
-        return "no data";
+        return dollarDataSource.getDollarInfo()
+                .map(info -> (info.getBlue() - info.getOficial())*100/info.getBlue())
+                .map(diff -> String.format("%s%%", diff.intValue()))
+                .orElse("no data");
     }
 }

--- a/src/main/java/com/acolque/miniwalletapi/services/DollarService.java
+++ b/src/main/java/com/acolque/miniwalletapi/services/DollarService.java
@@ -4,8 +4,6 @@ import com.acolque.miniwalletapi.datasource.apis.DollarDataSource;
 import com.acolque.miniwalletapi.entities.DollarInfoDto;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 public class DollarService {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+caching:
+  ttl:
+    general: 60000

--- a/src/test/java/com/acolque/miniwalletapi/controllers/DollarControllerTest.java
+++ b/src/test/java/com/acolque/miniwalletapi/controllers/DollarControllerTest.java
@@ -12,10 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
-public class WalletControllerTest {
+public class DollarControllerTest {
 
     @Autowired
-    private WalletController controller;
+    private DollarController controller;
 
     @MockBean
     private DollarService dollarService;

--- a/src/test/java/com/acolque/miniwalletapi/integrations/CryptoYaApiIntegrationTest.java
+++ b/src/test/java/com/acolque/miniwalletapi/integrations/CryptoYaApiIntegrationTest.java
@@ -1,0 +1,69 @@
+package com.acolque.miniwalletapi.integrations;
+
+import com.acolque.miniwalletapi.datasource.apis.CryptoYaApi;
+import com.acolque.miniwalletapi.entities.DollarInfoDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.interceptor.SimpleKey;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+import static com.acolque.miniwalletapi.configs.CacheConfig.CRYPTO_YA_API_CACHE_NAME;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+public class CryptoYaApiIntegrationTest {
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private CryptoYaApi api;
+
+    @MockBean
+    private RestTemplate restTemplate;
+
+    private final String CACHE_NAME = CRYPTO_YA_API_CACHE_NAME;
+
+    @BeforeEach
+    public void before() {
+        cacheManager.getCache(CACHE_NAME).clear();
+    }
+
+    @Test
+    public void testCacheAddValueSuccess() {
+        when(restTemplate.getForObject(anyString(), any())).thenReturn(DollarInfoDto.builder().build());
+
+        Optional<DollarInfoDto> optionalResult = api.getDollarInfo();
+
+        verify(restTemplate, atLeastOnce()).getForObject(anyString(), any());
+        assertTrue(optionalResult.isPresent());
+        assertCacheValue(optionalResult.get());
+    }
+
+    @Test
+    public void testCacheValueExistsSuccess() {
+        cacheManager.getCache(CACHE_NAME).put(SimpleKey.EMPTY, DollarInfoDto.builder().build());
+
+        Optional<DollarInfoDto> optionalResult = api.getDollarInfo();
+
+        verifyNoInteractions(restTemplate);
+        assertTrue(optionalResult.isPresent());
+        assertCacheValue(optionalResult.get());
+    }
+
+    private void assertCacheValue(DollarInfoDto dto) {
+        Cache cache = cacheManager.getCache(CACHE_NAME);
+        Cache.ValueWrapper value = cache.get(SimpleKey.EMPTY);
+        assertNotNull(value);
+        assertEquals(dto, value.get());
+    }
+}


### PR DESCRIPTION
## Qué
Modifico el controller de wallet renombrando a `DollarController`. También agrego caché de 1 minuto a la api de crypto ya.

## Cómo
Haciendo uso de `@Cacheable` y agregando un test de integración para verificar el correcto funcionamiento de la caché.

_Nota: la caché por ahora es **in memory**_